### PR TITLE
Namespaced all variables, Capitalized Tasks, Whitespace fix and removed block in file usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ php_fpm_php_ini_values:
     option: OPTION NAME
     value: VALUE
 ```
-| Name                      | Required                 | Description       | 
-|---------------------------|:------------------------:|---------------|
-| `section`          | :heavy_check_mark:       | Name from the php ini file section where the variable is supposed to live.        |
-| `option`          | :heavy_check_mark:         | The actuall variable name |
-| `value`          | :heavy_check_mark:         | The value that the option should have|
+| Name      |      Required      | Description                                                                |
+|:----------|:------------------:|:---------------------------------------------------------------------------|
+| `section` | :heavy_check_mark: | Name from the php ini file section where the variable is supposed to live. |
+| `option`  | :heavy_check_mark: | The actuall variable name                                                  |
+| `value`   | :heavy_check_mark: | The value that the option should have                                      |
 
 For a domain
 
-| Name                      | Required                 | Description       | 
-|---------------------------|:------------------------:|---------------|
-| `name`          | :heavy_check_mark:       | Name of the pool         |
-| `listen`          | :heavy_check_mark:         | The address on which to accept FastCGI requests. Valid syntaxes are: 'ip.add.re.ss:port', 'port', '/path/to/unix/socket'. This option is mandatory for each pool.  |
-| `user`          | :heavy_check_mark:         | Unix user of FPM processes. This option is mandatory.|
-| `pm`          | :heavy_check_mark:           | Choose how the process manager will control the number of child processes. Possible values: static, ondemand, dynamic. This option is mandatory. |
-| `pm.max_children`          | :heavy_multiplication_x:         | The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic. This option is mandatory if pm is set to dynamic or static. |
+| Name              |         Required         | Description                                                                                                                                                                                                         |
+|:------------------|:------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `name`            |    :heavy_check_mark:    | Name of the pool                                                                                                                                                                                                    |
+| `listen`          |    :heavy_check_mark:    | The address on which to accept FastCGI requests. Valid syntaxes are: 'ip.add.re.ss:port', 'port', '/path/to/unix/socket'. This option is mandatory for each pool.                                                   |
+| `user`            |    :heavy_check_mark:    | Unix user of FPM processes. This option is mandatory.                                                                                                                                                               |
+| `pm`              |    :heavy_check_mark:    | Choose how the process manager will control the number of child processes. Possible values: static, ondemand, dynamic. This option is mandatory.                                                                    |
+| `pm.max_children` | :heavy_multiplication_x: | The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic. This option is mandatory if pm is set to dynamic or static. |
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ To see all vars possible for php-fpm see
 
 To see all vars possible for php.ini see
 [php.ini page](https://secure.php.net/manual/de/ini.list.php)
+To pass those vars to ansible you use the list
+`php_fpm_php_ini_values` the syntax for this is as follows
+```
+php_fpm_php_ini_values:
+  - section: SECTION NAME
+    option: OPTION NAME
+    value: VALUE
+```
+| Name                      | Required                 | Description       | 
+|---------------------------|:------------------------:|---------------|
+| `section`          | :heavy_check_mark:       | Name from the php ini file section where the variable is supposed to live.        |
+| `option`          | :heavy_check_mark:         | The actuall variable name |
+| `value`          | :heavy_check_mark:         | The value that the option should have|
 
 For a domain
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ php_fpm_pools:
     pm_max_children: 20
     pm_start_servers: 20
     processes_priority: -19
-php_fpm_php_ini_values: 
-  apc.enabled:
-    - 1
-  extension:
-    - php_mysqli.dll
-    - php_ldap.dll
+php_fpm_php_ini_values:
+  - section: APC
+    option: apc.enabled
+    value: 1
+  - section: PHP
+    option: extension
+    value: php_mysqli
+  - section: PHP
+    option: extension
+    value: php_ldap
 php_fpm_log_level: error
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,4 +27,6 @@ php_fpm_clear_env: Yes
 php_fpm_security_limit_extensions: .php .phar
 php_fpm_access_format: "%R - %u %t \"%m %r\" %s"
 php_fpm_php_ini_values:
-  expose_php: 0
+  - section: PHP
+    option: expose_php
+    value: 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 galaxy_info:
-  author: Fritz Otlinghaus 
+  author: Fritz Otlinghaus
   description: Ansible php-fpm role
   company: stuvus (https://stuvus.uni-stuttgart.de)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,16 +11,13 @@
     state: absent
 
 - name: Update php.ini
-  blockinfile:
+  ini_file:
     path: "/etc/php/{{ php_fpm_php_version }}/fpm/php.ini"
-    marker: "; {mark} ANSIBLE MANAGED BLOCK"
-    backup: yes
-    block: |
-     {% for key in php_fpm_php_ini_values.keys() %}
-      {% for value in php_fpm_php_ini_values[key]%}
-        {{ key }}={{ value }}
-      {% endfor %} 
-     {% endfor %}
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value}}"
+  with_items:
+    php_fpm_php_ini_values
   register: reload_php
 
 - name: Create php-fpm.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,8 +16,7 @@
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value}}"
-  with_items:
-    php_fpm_php_ini_values
+  with_items: "{{ php_fpm_php_ini_values }}"
   register: reload_php
 
 - name: Create php-fpm.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,17 +7,17 @@
 
 - name: delete default php-fpm pool.conf
   file:
-    path: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
+    path: "/etc/php/{{ php_fpm_php_version }}/fpm/pool.d/www.conf"
     state: absent
 
 - name: Update php.ini
   blockinfile:
-    path: "/etc/php/{{ php_version }}/fpm/php.ini"
+    path: "/etc/php/{{ php_fpm_php_version }}/fpm/php.ini"
     marker: "; {mark} ANSIBLE MANAGED BLOCK"
     backup: yes
     block: |
-     {% for key in php_ini_values.keys() %}
-      {% for value in php_ini_values[key]%}
+     {% for key in php_fpm_php_ini_values.keys() %}
+      {% for value in php_fpm_php_ini_values[key]%}
         {{ key }}={{ value }}
       {% endfor %} 
      {% endfor %}
@@ -26,21 +26,21 @@
 - name: Create php-fpm.conf
   template:
     src: templates/php-fpm.conf.j2
-    dest: "/etc/php/{{ php_version }}/fpm/php-fpm.conf"
+    dest: "/etc/php/{{ php_fpm_php_version }}/fpm/php-fpm.conf"
   register: reload_php
 
 - name: Create php-fpm pool.confs
   template:
     src: templates/pool.conf.j2
-    dest:  "/etc/php/{{ php_version }}/fpm/pool.d/{{ pool.name }}.conf"
+    dest:  "/etc/php/{{ php_fpm_php_version }}/fpm/pool.d/{{ php_fpm_pool.name }}.conf"
   with_items: "{{ php_fpm_pools }}"
   loop_control:
-    loop_var: pool
+    loop_var: php_fpm_pool
   register: reload_php
 
 - name: Enable and start php-fpm
   systemd:
-    name: "php{{ php_version }}-fpm.service"
+    name: "php{{ php_fpm_php_version }}-fpm.service"
     state: reloaded
     enabled: True
   when: ansible_service_mgr == "systemd" and reload_php.changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     update_cache: yes
   when: ansible_pkg_mgr == "apt"
 
-- name: delete default php-fpm pool.conf
+- name: Delete default php-fpm pool.conf
   file:
     path: "/etc/php/{{ php_fpm_php_version }}/fpm/pool.d/www.conf"
     state: absent

--- a/templates/php-fpm.conf.j2
+++ b/templates/php-fpm.conf.j2
@@ -1,4 +1,4 @@
-; {{ php_fpm_ansible_managed }}
+; {{ ansible_managed }}
 ;;;;;;;;;;;;;;;;;;;;;
 ; FPM Configuration ;
 ;;;;;;;;;;;;;;;;;;;;;
@@ -23,7 +23,7 @@ include = /etc/php/{{php_version}}/fpm/conf.d/*.conf
 ; Note: the default prefix is /var
 ; Default Value: none
 {% if php_fpm_pid is defined %}
-    pid = {{ php_fpm_pid }}    
+    pid = {{ php_fpm_pid }}
 {% endif %}
 
 
@@ -54,7 +54,7 @@ syslog.ident = {{ php_fpm_syslog_ident }}
 ; Default Value: 0
 emergency_restart_threshold = {{ php_fpm_emergency_restart_threshold }}
 
-; Interval of time used by emergency_restart_interval to determine when 
+; Interval of time used by emergency_restart_interval to determine when
 ; a graceful restart will be initiated.  This can be useful to work around
 ; accidental corruptions in an accelerator's shared memory.
 ; Available Units: s(econds), m(inutes), h(ours), or d(ays)
@@ -68,10 +68,10 @@ emergency_restart_interval = {{ php_fpm_emergency_restart_interval }}
 ; Default Value: 0
 process_control_timeout = {{ php_fpm_process_control_timeout }}
 
-; The maximum number of processes FPM will fork. 
+; The maximum number of processes FPM will fork.
 ; This has been design to control the global number of processes
-; when using dynamic PM within a lot of pools. 
-; Use it with caution. 
+; when using dynamic PM within a lot of pools.
+; Use it with caution.
 ; Default value: 0.
 process.max = {{ php_fpm_process_max }}
 
@@ -79,7 +79,7 @@ process.max = {{ php_fpm_process_max }}
 ; The value can vary from -19 (highest priority) to 20 (lower priority).
 ; Default value: not set.
 {% if php_fpm_process_priority  is defined %}
-    process.priority = {{ php_fpm_process_priority }}    
+    process.priority = {{ php_fpm_process_priority }}
 {% endif %}
 
 ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
@@ -89,7 +89,7 @@ daemonize = {{ php_fpm_daemonize }}
 ;Set open file descriptor rlimit for the master process.
 ; Default value: not specifyed in doc
 {% if php_fpm_rlimit_files is defined %}
-    rlimit_files = {{ php_fpm_rlimit_files }}    
+    rlimit_files = {{ php_fpm_rlimit_files }}
 {% endif %}
 
 ; Set max core size rlimit for the master process.
@@ -103,14 +103,14 @@ rlimit_core = {{ php_fpm_rlimit_core}}
     events.mechanism = {{ php_fpm_events_mechanism }}
 {% endif %}
 
-; When FPM is build with systemd integration, 
+; When FPM is build with systemd integration,
 ; specify the interval, in second, between health report notification to systemd.
 ; Set to 0 to disable
 ; Default value: 10.
 systemd_interval = {{ php_fpm_systemd_interval }}
 
 ;;;;;;;;;;;;;;;;;;;;
-; Pool Definitions ; 
+; Pool Definitions ;
 ;;;;;;;;;;;;;;;;;;;;
 
 ; Multiple pools of child processes may be started with different listening

--- a/templates/pool.conf.j2
+++ b/templates/pool.conf.j2
@@ -13,7 +13,7 @@ listen = {{ php_fpm_pool.listen | mandatory }}
 ; A value of '-1' means unlimited.
 ; Default value: -1.
 {% if php_fpm_pool.listen_backlog is defined %}
-    listen.backlog = {{ php_fpm_pool.listen_backlog }}   
+    listen.backlog = {{ php_fpm_pool.listen_backlog }}
 {% else %}
     listen.backlog = {{ php_fpm_listen_backlog }}
 {% endif %}
@@ -28,7 +28,7 @@ listen = {{ php_fpm_pool.listen | mandatory }}
 ; Default value: any. IPv6 addresses are allowed since PHP 5.5.20 and 5.6.4.
 
 {% if php_fpm_pool.listen_allowed_clients is defined %}
-    listen.allowed_clients = {{ php_fpm_pool.listen_allowed_clients }}    
+    listen.allowed_clients = {{ php_fpm_pool.listen_allowed_clients }}
 {% else %}
     listen.allowed_clients = {{ php_fpm_listen_allowed_clients }}
 {% endif %}
@@ -51,14 +51,14 @@ listen = {{ php_fpm_pool.listen | mandatory }}
 ; See listen.owner
 listen.mode = {{ php_fpm_pool.listen_mode | default(php_fpm_listen_mode) }}
 
-; When POSIX Access Control Lists are supported you can set them using this option. 
+; When POSIX Access Control Lists are supported you can set them using this option.
 ; When set, listen.owner and listen.group are ignored.
 ; Value is a comma separated list of user names. Since PHP 5.6.5.
 {% if php_fpm_pool.listen_acl_users is defined %}
     listen.acl_users = {{ php_fpm_pool.listen_acl_users }}
 {% endif %}
 
-; See listen.acl_users. 
+; See listen.acl_users.
 ; Value is a comma separated list of group names. Since PHP 5.6.5.
 {% if php_fpm_pool.listen_acl_groups is defined %}
     listen.acl_groups = {{ php_fpm_pool.listen_acl_groups }}
@@ -72,20 +72,20 @@ user = {{ php_fpm_pool.user | mandatory }}
     group = {{ php_fpm_pool.group }}
 {% endif %}
 
-; Choose how the process manager will control the number of child processes. 
+; Choose how the process manager will control the number of child processes.
 ; Possible values: static, ondemand, dynamic. This option is mandatory.
 ; static - the number of child processes is fixed (pm.max_children).
 ; ondemand - the processes spawn on demand (when requested, as opposed to dynamic, where pm.start_servers are started when the service is started.
 ; dynamic - the number of child processes is set dynamically based on the following directives: pm.max_children, pm.start_servers, pm.min_spare_servers, pm.max_spare_servers.
 pm = {{ php_fpm_pool.pm | mandatory }}
 
-; The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic. 
+; The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic.
 ; This option is mandatory.
-; This option sets the limit on the number of simultaneous requests that will be served. 
+; This option sets the limit on the number of simultaneous requests that will be served.
 ; Equivalent to the ApacheMaxClients directive with mpm_prefork and to the PHP_FCGI_CHILDREN environment variable in the original PHP FastCGI.
 {% if php_fpm_pool.pm == "ondemand"%}
 {% if php_fpm_pool.pm_max_children is defined %}
-pm.max_children = {{php_fpm_pool.pm_max_children}}    
+pm.max_children = {{php_fpm_pool.pm_max_children}}
 {% endif %}
 {% else %}
 pm.max_children = {{ php_fpm_pool.pm_max_children | mandatory }}
@@ -119,7 +119,7 @@ pm.max_children = {{ php_fpm_pool.pm_max_children | mandatory }}
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays).
 ; Default value: 10s.
 {% if php_fpm_pool.pm_process_idle_timeout is defined %}
-    pm.process_idle_timeout = {{ php_fpm_pool.pm_process_idle_timeout }}    
+    pm.process_idle_timeout = {{ php_fpm_pool.pm_process_idle_timeout }}
 {% else %}
     pm.process_idle_timeout = {{ php_fpm_pm_process_idle_timeout }}
 {% endif %}
@@ -136,7 +136,7 @@ pm.max_requests = {{ php_fpm_pool.pm_max_requests | default(php_fpm_pm_max_reque
 ; If this value is not set, no URI will be recognized as a status page.
 ; Default value: none.
 {% if php_fpm_pool.pm_status_path is defined %}
-    pm.status_path = {{ php_fpm_pool.pm_status_path }}    
+    pm.status_path = {{ php_fpm_pool.pm_status_path }}
 {% endif %}
 
 ; The ping URI to call the monitoring page of FPM.
@@ -161,7 +161,7 @@ pm.max_requests = {{ php_fpm_pool.pm_max_requests | default(php_fpm_pm_max_reque
 ; The value can vary from -19 (highest priority) to 20 (lower priority).
 ; Default value: not set.
 {% if php_fpm_pool.processes_priority is defined %}
-    process.priority = {{ php_fpm_pool.processes_priority }}    
+    process.priority = {{ php_fpm_pool.processes_priority }}
 {% endif %}
 
 
@@ -182,8 +182,8 @@ pm.max_requests = {{ php_fpm_pool.pm_max_requests | default(php_fpm_pm_max_reque
 {% endif %}
 
 
-; The timeout for serving a single request after which a PHP backtrace will be dumped to the 'slowlog' file. 
-; A value of '0' means 'Off'. 
+; The timeout for serving a single request after which a PHP backtrace will be dumped to the 'slowlog' file.
+; A value of '0' means 'Off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays).
 ; Default value: 0.
 {% if php_fpm_pool.request_slowlog_timeout is defined %}
@@ -192,14 +192,14 @@ pm.max_requests = {{ php_fpm_pool.pm_max_requests | default(php_fpm_pm_max_reque
     request_slowlog_timeout = {{ php_fpm_request_slowlog_timeout}}
 {% endif %}
 
-; The log file for slow requests. 
+; The log file for slow requests.
 ; Default value: #INSTALL_PREFIX#/log/php-fpm.log.slow.
 slowlog = {{ php_fpm_pool.slowlog | default(php_fpm_slowlog) }}
 
 ; Set open file descriptor rlimit for child processes in this pool.
 ; Default value: system defined value.
 {% if php_fpm_pool.rlimit_files is defined %}
-    rlimit_files = {{ php_fpm_pool.rlimit_files }}    
+    rlimit_files = {{ php_fpm_pool.rlimit_files }}
 {% endif %}
 
 ; limit_core int
@@ -269,5 +269,5 @@ slowlog = {{ php_fpm_pool.slowlog | default(php_fpm_slowlog) }}
 {% if php_fpm_pool.envs is defined %}
 {% for key in php_fpm_pool.envs.keys() %}
     env[{{ key }}] = {{  php_fpm_pool.envs[key] }}
-{% endfor %}    
+{% endfor %}
 {% endif %}


### PR DESCRIPTION
Namespaced all variables
Capitalized Tasks
Switched from block in file module to using the ini module for the php.ini
removed trailing whitespaces in all files
Document php_fpm_php_ini_values
fixes #15 #12 #17 #14 #20 #18 