### PR TITLE
Revert "Fix typo and documentation error"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ php_fpm_php_ini_values:
     option: OPTION NAME
     value: VALUE
 ```
+| Name      | Required           | Description                                                                |
+|:----------|:------------------:|:---------------------------------------------------------------------------|
+| `section` | :heavy_check_mark: | Name from the php ini file section where the variable is supposed to live. |
+| `option`  | :heavy_check_mark: | The actuall variable name                                                  |
+| `value`   | :heavy_check_mark: | The value that the option should have                                      |
 
-
-For a domain. A domain has to be a dict below `php_fpm_pools`
+For a domain
 
 | Name              |         Required         | Description                                                                                                                                                                                                         |
 |:------------------|:------------------------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -34,7 +38,7 @@ For a domain. A domain has to be a dict below `php_fpm_pools`
 | `listen`          |    :heavy_check_mark:    | The address on which to accept FastCGI requests. Valid syntaxes are: 'ip.add.re.ss:port', 'port', '/path/to/unix/socket'. This option is mandatory for each pool.                                                   |
 | `user`            |    :heavy_check_mark:    | Unix user of FPM processes. This option is mandatory.                                                                                                                                                               |
 | `pm`              |    :heavy_check_mark:    | Choose how the process manager will control the number of child processes. Possible values: static, ondemand, dynamic. This option is mandatory.                                                                    |
-| `pm_max_children` | :heavy_multiplication_x: | The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic. This option is mandatory if pm is set to dynamic or static. |
+| `pm.max_children` | :heavy_multiplication_x: | The number of child processes to be created when pm is set to static and the maximum number of child processes to be created when pm is set to dynamic. This option is mandatory if pm is set to dynamic or static. |
 
 
 


### PR DESCRIPTION
Reverts stuvusIT/php-fpm#30
The previous Pull-Request removed documentation of tasks that are still in use.