### PR TITLE
chore(main.yml, update_php_uni.yml) replace DEPRECATED ansible.builti…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     state: absent
 
 - name: Update php.ini
-  include: update_php_ini.yml
+  include_tasks: update_php_ini.yml
   with_dict: "{{ php_fpm_php_ini_values }}"
   loop_control:
     loop_var: section

--- a/tasks/update_php_ini.yml
+++ b/tasks/update_php_ini.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Update php.ini section
-  include: update_php_ini_option.yml
+  include_tasks: update_php_ini_option.yml
   with_dict: "{{ section.value }}"
   loop_control:
     loop_var: option


### PR DESCRIPTION
…n.include

ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.